### PR TITLE
endnotexml export filter

### DIFF
--- a/src/main/resources/resource/layout/myendnotexml.begin.layout
+++ b/src/main/resources/resource/layout/myendnotexml.begin.layout
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<file xmlns="http://bibtexml.sf.net/">
+  <records>

--- a/src/main/resources/resource/layout/myendnotexml.end.layout
+++ b/src/main/resources/resource/layout/myendnotexml.end.layout
@@ -1,0 +1,2 @@
+ </records>
+</file>

--- a/src/main/resources/resource/layout/myendnotexml.layout
+++ b/src/main/resources/resource/layout/myendnotexml.layout
@@ -1,0 +1,23 @@
+<record>
+      <entry id="\bibtexkey">
+        <article>
+  \begin{author}		<author>      \author 		</author>  		\end{author}
+  \begin{title} 		<title> 	\title         	</title>    	\end{title}
+  \begin{journal} 		<journal> 	\journal 		</journal>		\end{journal} 
+  \begin{year}      	<year>	\year				</year>			\end{year}
+\begin{volume}      	<volume>	\volume			</volume>		\end{volume}
+\begin{number}      	<number>	\number			</number>		\end{number}        
+\begin{pages}      		<pages>	\pages				</pages>		\end{pages} 
+\begin{abstract}      	<abstract>	\abstract		</abstract>		\end{abstract}  
+\begin{doi}      		<doi>	\doi				</doi>			\end{doi}      
+\begin{keywords}      	<keywords>	\keywords		</keywords>		\end{keywords}           
+
+         
+          <urls>
+            <pdf-urls>
+              <url>internal-pdf://\format[FileLink(pdf)]{\file}</url>
+            </pdf-urls>
+            </urls>
+        </article>
+      </entry>
+    </record>


### PR DESCRIPTION
This is an endnotexml export filter to be able to import Jabref references into Altas.ti.
It was developed by Blondina Elms Pastel and Aaron Elms 

NOTES:
• Formatters need to be added to the title, etc…
• All JabRef entries must have a title, otherwise the filter will not work.
• For Atlas.ti if you want TITLE of imported references to have the name of BIBTEXKEY use:
\begin{title} 		<title> 	\bibtexkey       	</title>    	\end{title}

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
